### PR TITLE
Remove broken patches from TU_Restock_Default.cfg

### DIFF
--- a/TURD/TU_Restock/TU_Restock_Default.cfg
+++ b/TURD/TU_Restock/TU_Restock_Default.cfg
@@ -1,3 +1,4 @@
+// edited by munktron239. to undo, hit CTRL-F and remove all instances of '-broken'
 //CREATED USING TURD_ConfigMaker
 
 //   ____    ___    __  __   __  __      _      _   _   ____  
@@ -134,7 +135,7 @@
     }
 }
 
-@PART[cupola]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[cupola-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // cannot be recolored with SSPER installed
 {
     MODULE
     {
@@ -730,7 +731,7 @@
     }
 }
 
-@PART[externalTankCapsule]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankCapsule-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // looks really bad
 {
     MODULE
     {
@@ -779,7 +780,7 @@
     }
 }
 
-@PART[externalTankToroid]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankToroid-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // looks really bad
 {
     MODULE
     {
@@ -811,7 +812,7 @@
     }
 }
 
-@PART[externalTankRound]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankRound-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // looks really bad
 {
     MODULE
     {
@@ -886,7 +887,7 @@
     }
 }
 
-@PART[radialRCSTank,rcsTankRadialLong]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[radialRCSTank-broken,rcsTankRadialLong]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // doesnt work
 {
     MODULE
     {
@@ -1191,7 +1192,7 @@
     }
 }
 
-@PART[liquidEngineMainsail_v2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[liquidEngineMainsail_v2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // fairing looks really bad
 {
 	MODULE
     {
@@ -1535,7 +1536,7 @@
     }
 }
 
-@PART[RCSBlock_v2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[RCSBlock_v2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // all rcs blocks are broken
 {
     MODULE
     {
@@ -1601,7 +1602,7 @@
     }
 }
 
-@PART[RCSblock_01_small]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[RCSblock_01_small-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -1628,7 +1629,7 @@
     }
 }
 
-@PART[restock-rcs-block-multi-2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[restock-rcs-block-multi-2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -1657,7 +1658,7 @@
     }
 }
 
-@PART[restock-rcs-block-multi-mini-2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[restock-rcs-block-multi-mini-2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2233,7 +2234,7 @@
     }
 }
 
-@PART[adapterLargeSmallBi]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallBi-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // all 6 stack adapters look really bad
 {
     MODULE
     {
@@ -2266,7 +2267,7 @@
     }
 }
 
-@PART[adapterLargeSmallTri]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallTri-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2299,7 +2300,7 @@
     }
 }
 
-@PART[adapterLargeSmallQuad]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallQuad-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2332,7 +2333,7 @@
     }
 }
 
-@PART[stackBiCoupler_v2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackBiCoupler_v2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2365,7 +2366,7 @@
     }
 }
 
-@PART[stackTriCoupler_v2]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackTriCoupler_v2-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2398,7 +2399,7 @@
     }
 }
 
-@PART[stackQuadCoupler]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackQuadCoupler-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -2988,7 +2989,7 @@
     }
 }
 
-@PART[smallClaw]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[smallClaw-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // completely broken
 {
   !MODULE[KSPTextureSwitch],* {}
     MODULE
@@ -3053,7 +3054,7 @@
     }
 }
 
-@PART[GrapplingDevice]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[GrapplingDevice-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // completely broken
 {
   !MODULE[KSPTextureSwitch],* {}
     MODULE
@@ -3294,7 +3295,7 @@
     }
 }
 
-@PART[basicFin]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[basicFin-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // all 4 restock fins looks really bad
 {
     MODULE
     {
@@ -3324,7 +3325,7 @@
     }
 }
 
-@PART[winglet]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[winglet-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -3353,7 +3354,7 @@
     }
 }
 
-@PART[R8winglet]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[R8winglet-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -3382,7 +3383,7 @@
     }
 }
 
-@PART[winglet3]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[winglet3-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -3411,7 +3412,7 @@
     }
 }
 
-@PART[winglet3]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[winglet3-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     MODULE
     {
@@ -3590,15 +3591,15 @@
     }
 }
 
-@PART[HeatShield0,HeatShield3]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[HeatShield0,HeatShield3]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // textures for base are broken, fairing textures are fine
 {
-    MODULE
-    {
-        name = KSPTextureSwitch
-        sectionName = Base
-        currentTextureSet = Restock_HeatShield2_Base_Default
-        textureSet = Restock_HeatShield2_Base_Default
-    }
+//    MODULE
+//    {
+//        name = KSPTextureSwitch
+//        sectionName = Base
+//        currentTextureSet = Restock_HeatShield2_Base_Default
+//        textureSet = Restock_HeatShield2_Base_Default
+//    }
     MODULE
     {
         name = KSPTextureSwitch
@@ -3607,48 +3608,48 @@
         textureSet = Restock_HeatShield2_Fairing_Default
     }
 }
-+KSP_TEXTURE_SET[Restock_Default]:NEEDS[TexturesUnlimited&ReStock]
-{
-    @name = Restock_HeatShield2_Base_Default
-	@MATERIAL
-    {
-		mesh = HeatShield375Internal
-		
-		mesh = HeatShield0625Internal
-		
-        texture = _MainTex,ReStock/Assets/Aero/restock-heat-shield-2
-        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
-        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
-        
-        PROPERTY
-        {
-            name = _Shininess
-            float = 0.3
-        }
-    }
-	MATERIAL
-    {
-		shader = KSP/Emissive/Bumped Specular
-	
-		mesh = HeatShield375Black
-		mesh = HeatShield375Brown
-		mesh = HeatShield375Red
-		
-		mesh = HeatShield0625Black
-		mesh = HeatShield0625Brown
-		mesh = HeatShield0625Red
-		
-        texture = _MainTex,ReStock/Assets/Aero/restock-heat-shield-2
-        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
-        texture = _Emissive,TU_Restock/Default/DefaultEmis
-        
-        PROPERTY
-        {
-            name = _Shininess
-            float = 0.3
-        }
-    }
-}
+//+KSP_TEXTURE_SET[Restock_Default]:NEEDS[TexturesUnlimited&ReStock]
+//{
+//    @name = Restock_HeatShield2_Base_Default
+//	@MATERIAL
+//    {
+//		mesh = HeatShield375Internal
+//		
+//		mesh = HeatShield0625Internal
+//		
+//        texture = _MainTex,ReStock/Assets/Aero/restock-heat-shield-2
+//        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
+//        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
+//        
+//        PROPERTY
+//        {
+//            name = _Shininess
+//            float = 0.3
+//        }
+//    }
+//	MATERIAL
+//    {
+//		shader = KSP/Emissive/Bumped Specular
+//	
+//		mesh = HeatShield375Black
+//		mesh = HeatShield375Brown
+//		mesh = HeatShield375Red
+//		
+//		mesh = HeatShield0625Black
+//		mesh = HeatShield0625Brown
+//		mesh = HeatShield0625Red
+//		
+//        texture = _MainTex,ReStock/Assets/Aero/restock-heat-shield-2
+//        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
+//        texture = _Emissive,TU_Restock/Default/DefaultEmis
+//        
+//        PROPERTY
+//        {
+//            name = _Shininess
+//            float = 0.3
+//        }
+//    }
+//}
 +KSP_TEXTURE_SET[Restock_Default]:NEEDS[TexturesUnlimited&ReStock]
 {
     @name = Restock_HeatShield2_Fairing_Default
@@ -5371,7 +5372,7 @@
     }
 }
 
-@PART[fireworksLauncherBig,fireworksLauncherSmall]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[fireworksLauncherBig-broken,fireworksLauncherSmall-broken]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock] // doesnt work
 {
     MODULE
     {


### PR DESCRIPTION
I am proposing this change under the guise that this project is officially discontinued, and all this PR really does is remove some parts' ability to be repainted. 

I have gone through and tested the recoloring ability of each part covered in ReStock and ReStock+ on KSP 1.12.5 and have noted which parts have broken textures.

All changes are marked with '-broken' in the @PART[] patches for both TU_Restock_Default.cfg and TU_Restock_Recolour.cfg