### PR TITLE
(Part 2) Remove broken patches from TU_Restock_Recolour.cfg

### DIFF
--- a/TURD/TU_Restock/TU_Restock_Recolour.cfg
+++ b/TURD/TU_Restock/TU_Restock_Recolour.cfg
@@ -1,3 +1,4 @@
+// match changes made to other patch. to undo, hit CTRL-F and remove all instances of '-broken'
 //CREATED USING TURD_ConfigMaker
 
 //   ____    ___    __  __   __  __      _      _   _   ____  
@@ -155,7 +156,7 @@
     }
 }
 
-@PART[cupola]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[cupola-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -759,7 +760,7 @@
     }
 }
 
-@PART[externalTankCapsule]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankCapsule-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -810,7 +811,7 @@
     }
 }
 
-@PART[externalTankToroid]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankToroid-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -841,7 +842,7 @@
     }
 }
 
-@PART[externalTankRound]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[externalTankRound-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -929,7 +930,7 @@
     }
 }
 
-@PART[radialRCSTank,rcsTankRadialLong]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[radialRCSTank-broken,rcsTankRadialLong]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -1231,7 +1232,7 @@
     }
 }
 
-@PART[liquidEngineMainsail_v2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[liquidEngineMainsail_v2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -1650,7 +1651,7 @@
     }
 }
 
-@PART[RCSBlock_v2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[RCSBlock_v2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -1718,7 +1719,7 @@
     }
 }
 
-@PART[RCSblock_01_small]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[RCSblock_01_small-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -1746,7 +1747,7 @@
     }
 }
 
-@PART[restock-rcs-block-multi-2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[restock-rcs-block-multi-2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -1774,7 +1775,7 @@
     }
 }
 
-@PART[restock-rcs-block-multi-mini-2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[restock-rcs-block-multi-mini-2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2330,7 +2331,7 @@
     }
 }
 
-@PART[adapterLargeSmallBi]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallBi-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2364,7 +2365,7 @@
     }
 }
 
-@PART[adapterLargeSmallTri]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallTri-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2398,7 +2399,7 @@
     }
 }
 
-@PART[adapterLargeSmallQuad]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[adapterLargeSmallQuad-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2432,7 +2433,7 @@
     }
 }
 
-@PART[stackBiCoupler_v2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackBiCoupler_v2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2466,7 +2467,7 @@
     }
 }
 
-@PART[stackTriCoupler_v2]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackTriCoupler_v2-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -2500,7 +2501,7 @@
     }
 }
 
-@PART[stackQuadCoupler]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[stackQuadCoupler-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3195,7 +3196,7 @@
 	}
 }
 
-@PART[smallClaw]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[smallClaw-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3263,7 +3264,7 @@
     }
 }
 
-@PART[GrapplingDevice]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[GrapplingDevice-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3509,7 +3510,7 @@
     }
 }
 
-@PART[basicFin]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[basicFin-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3540,7 +3541,7 @@
     }
 }
 
-@PART[winglet]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[winglet-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3568,7 +3569,7 @@
     }
 }
 
-@PART[R8winglet]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[R8winglet-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3596,7 +3597,7 @@
     }
 }
 
-@PART[winglet3]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[winglet3-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {
@@ -3775,10 +3776,10 @@
 
 @PART[HeatShield0,HeatShield3]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
-	@MODULE[KSPTextureSwitch],0
-    {
-        textureSet = Restock_HeatShield2_Base_Paint
-    }
+//	@MODULE[KSPTextureSwitch],0
+//    {
+//        textureSet = Restock_HeatShield2_Base_Paint
+//    }
 	@MODULE[KSPTextureSwitch],1
     {
         textureSet = Restock_HeatShield2_Fairing_Paint
@@ -3788,49 +3789,49 @@
         %name = SSTURecolorGUI
     }
 }
-+KSP_TEXTURE_SET[Restock_Paint]:NEEDS[TexturesUnlimited&ReStock]
-{
-    @name = Restock_HeatShield2_Base_Paint
-	@MATERIAL
-    {
-		mesh = HeatShield375Internal
-		
-		mesh = HeatShield0625Internal
-		
-        texture = _MainTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-base
-        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
-        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
-        texture = _MetallicGlossMap,TURD/TU_Restock/Default/DefaultSpec
-        texture = _MaskTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-paint
-        
-        vector = _DiffuseNorm,0.75,0.75,0.75
-        vector = _MetalNorm,0.55,0.55,0.55
-        vector = _SmoothnessNorm,0.55,0.55,0.55
-    }
-	MATERIAL
-    {
-		shader = TU/Metallic
-		keyword = TU_RECOLOR
-	
-		mesh = HeatShield375Black
-		mesh = HeatShield375Brown
-		mesh = HeatShield375Red
-		
-		mesh = HeatShield0625Black
-		mesh = HeatShield0625Brown
-		mesh = HeatShield0625Red
-		
-        texture = _MainTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-base
-        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
-        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
-        texture = _MetallicGlossMap,TURD/TU_Restock/Default/DefaultSpec
-        texture = _MaskTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-paint
-        
-        vector = _DiffuseNorm,0.75,0.75,0.75
-        vector = _MetalNorm,0.55,0.55,0.55
-        vector = _SmoothnessNorm,0.55,0.55,0.55
-    }
-}
+//+KSP_TEXTURE_SET[Restock_Paint]:NEEDS[TexturesUnlimited&ReStock]
+//{
+//    @name = Restock_HeatShield2_Base_Paint
+//	@MATERIAL
+//    {
+//		mesh = HeatShield375Internal
+//		
+//		mesh = HeatShield0625Internal
+//		
+//        texture = _MainTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-base
+//        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
+//        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
+//        texture = _MetallicGlossMap,TURD/TU_Restock/Default/DefaultSpec
+//        texture = _MaskTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-paint
+//        
+//        vector = _DiffuseNorm,0.75,0.75,0.75
+//        vector = _MetalNorm,0.55,0.55,0.55
+//        vector = _SmoothnessNorm,0.55,0.55,0.55
+//    }
+//	MATERIAL
+//    {
+//		shader = TU/Metallic
+//		keyword = TU_RECOLOR
+//	
+//		mesh = HeatShield375Black
+//		mesh = HeatShield375Brown
+//		mesh = HeatShield375Red
+//		
+//		mesh = HeatShield0625Black
+//		mesh = HeatShield0625Brown
+//		mesh = HeatShield0625Red
+//		
+//        texture = _MainTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-base
+//        texture = _BumpMap,ReStock/Assets/Aero/restock-heat-shield-2-n
+//        texture = _Emissive,TURD/TU_Restock/Default/DefaultEmis
+//        texture = _MetallicGlossMap,TURD/TU_Restock/Default/DefaultSpec
+//        texture = _MaskTex,TURD/TU_Restock/Parts/Thermal/HeatShields/restock-heat-shield-2-paint
+//        
+//        vector = _DiffuseNorm,0.75,0.75,0.75
+//        vector = _MetalNorm,0.55,0.55,0.55
+//        vector = _SmoothnessNorm,0.55,0.55,0.55
+//    }
+//}
 +KSP_TEXTURE_SET[Restock_Paint]:NEEDS[TexturesUnlimited&ReStock]
 {
     @name = Restock_HeatShield2_Fairing_Paint
@@ -5617,7 +5618,7 @@
     }
 }
 
-@PART[fireworksLauncherBig,fireworksLauncherSmall]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
+@PART[fireworksLauncherBig-broken,fireworksLauncherSmall-broken]:FOR[999_TU_Restock_Recolour_000]:NEEDS[TexturesUnlimited&ReStock]
 {
     @MODULE[KSPTextureSwitch],0
     {


### PR DESCRIPTION
(This is the second part of the pull request - I couldn't figure out how to merge the 2 of them together)

I am proposing this change under the guise that this project is officially discontinued, and all this PR really does is remove some parts' ability to be repainted. 

I have gone through and tested the recoloring ability of each part covered in ReStock and ReStock+ on KSP 1.12.5 and have noted which parts have broken textures.

All changes are marked with '-broken' in the @PART[] patches for both TU_Restock_Default.cfg and TU_Restock_Recolour.cfg