### PR TITLE
FIX: Extra closing bracket causing some configs to not get loaded

### DIFF
--- a/TURD/TU_Restock/TU_Restock_Default.cfg
+++ b/TURD/TU_Restock/TU_Restock_Default.cfg
@@ -3213,8 +3213,6 @@
     	}	
 }
 
-}
-
 @PART[dockingPort1]:FOR[000_TU_Restock_000]:NEEDS[TexturesUnlimited&ReStock]
 {
 	MODULE


### PR DESCRIPTION
Hey, I noticed that theres a bracket here that causes half the config to not load.